### PR TITLE
Add python 3 compatibility with unit tests; add "data" endpoint.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 *.pyc
+.coverage
+.tox/*
 dist
 build
 MANIFEST

--- a/circonusapi/circonusapi.py
+++ b/circonusapi/circonusapi.py
@@ -103,20 +103,28 @@ class CirconusAPI(object):
         method, endpoint = name.split('_', 1)
         if method in self.methods and endpoint in self.endpoints:
             if self.methods[method]['id']:
-                def f(resource_id=None, data=None):
-                    return self.api_call(self.methods[method]['method'],
-                            "%s/%s" % (endpoint, resource_id), data)
+                def f(resource_id=None, data=None, params=None):
+                    return self.api_call(
+                        self.methods[method]['method'],
+                        "%s/%s" % (endpoint, resource_id),
+                        data=data,
+                        params=params
+                    )
                 return f
             else:
                 def g(data=None, params={}):
-                    return self.api_call(self.methods[method]['method'],
-                            endpoint, data, params)
+                    return self.api_call(
+                        self.methods[method]['method'],
+                        endpoint,
+                        data=data,
+                        params=params
+                    )
                 return g
         else:
             raise AttributeError("%s instance has no attribute '%s'" % (
                 self.__class__.__name__, name))
 
-    def api_call(self, method, endpoint, data=None, params={}):
+    def api_call(self, method, endpoint, data=None, params=None):
         """Performs a circonus api call."""
 
         # Encode data as json if it isn't already. You can pass a json encoded
@@ -125,8 +133,7 @@ class CirconusAPI(object):
             data = json.dumps(data)
 
         # Allow specifying an endpoint both with and without a leading /
-        if endpoint[0] == '/':
-            endpoint = endpoint[1:]
+        endpoint = endpoint.lstrip('/')
         endpoint = quote(endpoint)
         if params:
             endpoint = '%s?%s' % (endpoint, urlencode(

--- a/circonusapi/config.py
+++ b/circonusapi/config.py
@@ -1,28 +1,31 @@
-import ConfigParser
 import os
+import logging
+
+try:
+    from ConfigParser import SafeConfigParser
+except ImportError:
+    # python 3.2+
+    from configparser import ConfigParser as SafeConfigParser
+
+
+log = logging.getLogger(__name__)
 
 _cached_config = None
 
-def load_config(configfile=None):
+def load_config(configfile=None, nocache=False):
     global _cached_config
-    if _cached_config:
+    if _cached_config and not nocache:
         return _cached_config
 
-    config = ConfigParser.SafeConfigParser()
-
-   # # First load the default config
-   # try:
-   #     config.readfp(open(os.path.join(os.path.dirname(__file__),
-   #                                         "..", "data", "defaults")))
-   # except IOError:
-   #     print "Unable to load default configuraiton. The program"
-   #             " may not work correctly."
-
-    # Now load the system/user specific config (if any)
-    if configfile:
-        config.read([configfile])
-    else:
-        config.read(['/etc/circonusapirc',
-                                os.path.expanduser('~/.circonusapirc')])
+    config = SafeConfigParser()
+    config_files = configfile or [
+        '/etc/circonusapirc',
+        os.path.expanduser('~/.circonusapirc')
+    ]
+    if not config.read(config_files):
+        log.warning(
+            "Unable to load default configuraiton. "
+            "The program  may not work correctly."
+        )
     _cached_config = config
     return config

--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,19 @@
-#!/usr/bin/env python
 from distutils.core import setup
 
 setup (
     name="circonusapi",
-    version="0.1.4",
+    version="0.2.5",
     description="Circonus API library",
     author="Mark Harrison",
     author_email="mark@omniti.com",
     url="http://github.com/omniti-labs/circonusapi",
     license="ISC",
-    classifiers = [
+    classifiers=[
         "Programming Language :: Python",
         "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.7",
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         "Development Status :: 4 - Beta",
         "Environment :: Other Environment",
         "Intended Audience :: Developers",

--- a/test_circonusapi.py
+++ b/test_circonusapi.py
@@ -1,0 +1,112 @@
+'''
+To test actual endpoints create a valid config file and point to it.
+
+Example:
+
+CIRCONUS_CONFIG=/tmp/test_circonus_config.ini tox
+
+
+'''
+import os
+
+from tempfile import NamedTemporaryFile
+from unittest import TestCase
+
+from circonusapi import circonusapi, config
+
+
+class ConfigTestCase(TestCase):
+
+    def test_no_config_file(self):
+        cfg = config.load_config(configfile='nope', nocache=True)
+        self.assertEqual(cfg.sections(), [])
+
+    def test_single_config_file(self):
+        with NamedTemporaryFile(mode='w+') as tmp_file:
+            tmp_file.file.write(
+                '''
+[general]
+default_account=sampleaccount
+appname=sample appname
+
+[tokens]
+sampleaccount=AAAAAAAA-1234-5678-9999-BBBBBBBB
+'''
+            )
+            tmp_file.file.flush()
+            tmp_file.file.seek(0)
+            cfg = config.load_config(
+                configfile=tmp_file.name,
+                nocache=True
+            )
+            self.assertEqual(cfg.get('general', 'appname'), 'sample appname')
+            cfg_cached = config.load_config()
+            self.assertEqual(cfg_cached.get('general', 'appname'), 'sample appname')
+
+
+    def test_two_merged_config_files(self):
+        config_txt_1 = '''
+[general]
+default_account=sampleaccount
+appname=sample appname
+'''
+        config_txt_2 = '''
+[tokens]
+sampleaccount=AAAAAAAA-1234-5678-9999-BBBBBBBB
+'''
+        with NamedTemporaryFile(mode='w+') as tmp_file_1:
+            with NamedTemporaryFile(mode='w+') as tmp_file_2:
+                tmp_file_1.write(config_txt_1)
+                tmp_file_2.write(config_txt_2)
+                for cfl in [tmp_file_1, tmp_file_2]:
+                    cfl.file.flush()
+                    cfl.file.seek(0)
+                cfg = config.load_config(
+                    configfile=[
+                        tmp_file_1.name,
+                        tmp_file_2.name
+                    ],
+                    nocache=True
+                )
+            self.assertEqual(cfg.get('general', 'appname'), 'sample appname')
+            self.assertEqual(cfg.get('tokens', 'sampleaccount'), 'AAAAAAAA-1234-5678-9999-BBBBBBBB')
+
+
+class CirconusAPITestCase(TestCase):
+
+    def setUp(self):
+        config_file = os.environ.get('CIRCONUS_CONFIG')
+        cfg = config.load_config(configfile=config_file, nocache=True)
+        account = cfg.get('general', 'default_account')
+        appname = cfg.get('general', 'appname')
+        token = cfg.get('tokens', account)
+        api = circonusapi.CirconusAPI(token)
+        api.appname = appname
+        self.config = cfg
+        self.api = api
+
+    def test_brokers(self):
+        brokers = self.api.list_broker()
+        self.assertTrue(len(brokers) > 10)
+
+    def test_wrong_method(self):
+        try:
+            result = self.api.list_foobar()
+        except AttributeError:
+            pass
+
+    def test_data_wrong_format(self):
+        '''
+        Test 'data' endpoint and whether errors properly deserialized.
+
+        '''
+        try:
+            result = self.api.get_data(123)
+        except circonusapi.CirconusAPIError as e:
+            self.assertEqual(e.code, 400)
+            self.assertTrue('format' in e.message)
+
+    def test_check_bundle(self):
+        bundles = self.api.list_check_bundle()
+        self.assertTrue(type(bundles) is list)
+

--- a/test_circonusapi.py
+++ b/test_circonusapi.py
@@ -95,6 +95,18 @@ class CirconusAPITestCase(TestCase):
         except AttributeError:
             pass
 
+    def test_data_endpoint(self):
+        result = self.api.get_data(
+            '159841_available',
+            params=dict(
+                type='numeric',
+                start=1362400895,
+                end=1362487307,
+                period=300
+            )
+        )
+        self.assertTrue(len(result.get('data')) > 20) 
+
     def test_data_wrong_format(self):
         '''
         Test 'data' endpoint and whether errors properly deserialized.
@@ -106,7 +118,14 @@ class CirconusAPITestCase(TestCase):
             self.assertEqual(e.code, 400)
             self.assertTrue('format' in e.message)
 
-    def test_check_bundle(self):
-        bundles = self.api.list_check_bundle()
-        self.assertTrue(type(bundles) is list)
+    def test_contact_group(self):
+        contacts = self.api.list_contact_group()
+        self.assertTrue(type(contacts) is list)
+
+    def test_search_dns_bundles(self):
+        dns_bundles = self.api.list_check_bundle(
+            params=dict(f_type='dns')
+        )
+        for bundle in dns_bundles:
+            self.assertEqual(bundle.get('type'), 'dns')
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,11 @@
+[tox]
+envlist = py26,py27,py33,py34,py35
+
+[testenv]
+deps = 
+        nose
+        coverage
+commands = 
+        nosetests --nologcapture -s --with-coverage --cover-package=circonusapi.circonusapi,circonusapi.config
+
+passenv = CIRCONUS_CONFIG


### PR DESCRIPTION
Tests were run using tox on:
Ubuntu 16:04 with Python 2.7 and 3.5
Centos 6.7 with Python 2.6 and 3.3 using SCL repository

```
Name                         Stmts   Miss  Cover
------------------------------------------------
circonusapi/circonusapi.py     100      5    95%
circonusapi/config.py           17      0   100%
------------------------------------------------
TOTAL                          117      5    96%
----------------------------------------------------------------------
Ran 7 tests in 0.925s

OK
________________________________________________ summary _________________________________________________
  py26: commands succeeded
  py27: commands succeeded
  py33: commands succeeded
ERROR:   py34: InterpreterNotFound: python3.4
  py35: commands succeeded
```
